### PR TITLE
Enhanced Command-Line Argument Parsing and Merged Pak Cleanup

### DIFF
--- a/Stalker2PakCfgMergeTool/Program.cs
+++ b/Stalker2PakCfgMergeTool/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+
 using Stalker2PakCfgMergeTool.Entities;
 using Stalker2PakCfgMergeTool.Implementations;
 
@@ -12,12 +13,58 @@ public class Program
 
     public static async Task Main(string[] args)
     {
-        var gamePath = args.FirstOrDefault() ?? "";
-        var aesKey = args.Skip(1).FirstOrDefault();
+        string gamePath = "";
+        string? aesKey = null;
+        bool skipReport = false;
+
+
+
+        for (int i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--aes":
+                    if (i + 1 < args.Length)
+                    {
+                        aesKey = args[i + 1];
+                        i++;
+                    }
+                    else
+                    {
+                        Console.WriteLine("Error: Missing value for --aes option.");
+                        PressAnyKeyToExit();
+                        return;
+                    }
+                    break;
+                case "--skipreport":
+                    skipReport = true;
+                    break;
+
+                default:
+                    if (string.IsNullOrEmpty(gamePath))
+                    {
+                        gamePath = args[i];
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Error: Unknown argument '{args[i]}'.");
+                        PressAnyKeyToExit();
+                        return;
+                    }
+                    break;
+            }
+        }
+
+        if (string.IsNullOrEmpty(gamePath))
+        {
+            Console.WriteLine("Error: Missing required game path argument.");
+            PressAnyKeyToExit();
+            return;
+        }
 
         try
         {
-            await Execute(gamePath, aesKey);
+            await Execute(gamePath, aesKey, skipReport);
         }
         catch (Exception e)
         {
@@ -28,7 +75,7 @@ public class Program
         }
     }
 
-    private static async Task Execute(string gamePath, string? aesKey)
+    private static async Task Execute(string gamePath, string? aesKey, bool skipReport = false)
     {
         if (string.IsNullOrEmpty(gamePath) || !Directory.Exists(gamePath))
         {
@@ -115,6 +162,13 @@ public class Program
         var mergedPakName = $"{filePrefix}_{Constants.MergedPakBaseName}_{currentDate}_P.pak";
         var mergedPakPath = Path.Combine(gamePath, paksDirectory, ModsDirectoryName, mergedPakName);
 
+        //cleanup old merged pak files
+        var oldMergedPakFiles = dirInfo.GetFiles($"{filePrefix}_{Constants.MergedPakBaseName}_*.pak");
+        foreach (var oldMergedPakFile in oldMergedPakFiles)
+        {
+            oldMergedPakFile.Delete();
+        }
+
         if (Debug.IsDebug && Debug.ExportToFolder)
         {
             await Debug.ExportMergeToFolder(mergedPakName, Path.Combine(gamePath, paksDirectory, ModsDirectoryName, "merged"), mergedPakFiles);
@@ -127,17 +181,20 @@ public class Program
 
         Console.WriteLine($"Merge pak created: {mergedPakName}\n\n");
 
-        Console.WriteLine("Open up the Diff Viewer? [y/n]\n");
-
-        if (Console.ReadKey().KeyChar == 'y')
+        if (!skipReport)
         {
-            var summaryFilePath = Path.Combine(Directory.GetCurrentDirectory(), "diff.html");
-            var processStartInfo = new ProcessStartInfo
+            Console.WriteLine("Open up the Diff Viewer? [y/n]\n");
+
+            if (Console.ReadKey().KeyChar == 'y')
             {
-                FileName = summaryFilePath,
-                UseShellExecute = true
-            };
-            Process.Start(processStartInfo);
+                var summaryFilePath = Path.Combine(Directory.GetCurrentDirectory(), "diff.html");
+                var processStartInfo = new ProcessStartInfo
+                {
+                    FileName = summaryFilePath,
+                    UseShellExecute = true
+                };
+                Process.Start(processStartInfo);
+            }
         }
     }
 


### PR DESCRIPTION
This will allow to add your tool into the `Vortex` like this:
![image](https://github.com/user-attachments/assets/80bc4ecb-5553-4362-b952-f1d9de36853a)
![image](https://github.com/user-attachments/assets/16db43db-61f7-46c8-90d4-ce07a5edcf74)


### Refactored the Main method to improve argument parsing.
- Updated Execute method to include `--skipreport` logic.
- Added cleanup logic for old merged pak files.
- Minor structural and formatting improvements across the codebase.

### Command Arguments
- Refactored Main method to handle command-line arguments more robustly:
  - Added explicit initialization for gamePath, aesKey, and skipReport variables.
  - Introduced a for loop with a switch statement to parse command-line arguments.
  - Replaced the unnamed second argument for AES with the named option --aes.
  - Added a new boolean flag --skipreport for conditional processing.

### Merged Pak Cleanup:

- Implemented logic to clean up old merged pak files before creating new ones:
  - Identifies files matching the pattern for merged paks.
  - Deletes these files to ensure no leftover files from previous runs.

### Conditional Diff Viewer Logic:
  - Refactored the prompt for opening the Diff Viewer:
  - Integrated `--skipreport` to bypass this prompt when specified.
